### PR TITLE
Add pageWorld to web_accessible_resources

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -20,5 +20,13 @@
   "host_permissions": [
     "https://mail.google.com/"
   ],
+   "web_accessible_resources": [
+    {
+      "resources": ["pageWorld.js"],
+      "matches": [
+        "https://mail.google.com/*"
+      ]
+    }
+  ],
   "manifest_version": 3
 }


### PR DESCRIPTION
Without this, the pageWorld.js script cannot be loaded, so inboxsdk doesn't start